### PR TITLE
add Execution.get_all_values(execution_id) and Execution.get_value(execution_id, step_id)

### DIFF
--- a/lib/execution.ex
+++ b/lib/execution.ex
@@ -380,7 +380,7 @@ defmodule Journey.Execution do
   end
 
   @doc """
-  Get all steps in the execution, and their current state, given execution id.
+  Get all steps in the execution, and their current state.
 
   ```elixir
   iex(9)> execution_id |> Journey.Execution.get_all_values

--- a/lib/execution.ex
+++ b/lib/execution.ex
@@ -380,10 +380,10 @@ defmodule Journey.Execution do
   end
 
   @doc """
-  Get all steps in the execution, and their current state.
+  Get all steps in the execution, and their current state, given execution id.
 
   ```elixir
-  iex(9)> execution |> Journey.Execution.get_all_values
+  iex(9)> execution_id |> Journey.Execution.get_all_values
   [
   started_at: [
     status: :computed,
@@ -424,6 +424,12 @@ defmodule Journey.Execution do
   ]
   ```
   """
+  def get_all_values(execution_id) when is_binary(execution_id) do
+    execution_id
+    |> Journey.Execution.load!()
+    |> get_all_values()
+  end
+
   @spec get_all_values(Journey.Execution.t()) ::
           list(
             {:not_computed | :computed | :computing | :failed,
@@ -442,6 +448,23 @@ defmodule Journey.Execution do
           |> Enum.map(fn s -> s |> elem(0) end)
       }
     end)
+  end
+
+  @doc """
+  Fetches the value contained in a specificified step.
+
+  ```elixir
+  iex(1)> Journey.Execution.get_value(execution_id, :birth_day)
+  26
+  ```
+  """
+
+  def get_value(execution_id, value_id) do
+    execution =
+      execution_id
+      |> Journey.Execution.load!()
+
+    execution.values[value_id].value
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Journey.MixProject do
   def project do
     [
       app: :journey,
-      version: "0.0.4",
+      version: "0.0.5",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/journey_func_test.exs
+++ b/test/journey_func_test.exs
@@ -70,8 +70,9 @@ defmodule JourneyTestFunc do
     # Submit birth day.
     {:ok, execution} = Journey.Execution.update_value(execution.execution_id, :birth_day, 21)
     {:computed, 21} = Journey.Execution.read_value(execution, :birth_day)
-    all_values = Journey.Execution.get_all_values(execution)
+    all_values = Journey.Execution.get_all_values(execution.execution_id)
     assert Enum.count(all_values) == 7
+    assert Journey.Execution.get_value(execution.execution_id, :birth_day) == 21
 
     # Get all values.
     values = Journey.Execution.get_all_values(execution)


### PR DESCRIPTION

1. simplifying getting all values, given the id of an execution (instead of requiring the execution itself):

```elixir
Journey.Execution.get_all_values(execution_id)
```

2. simplifying getting the value of a specific step, given execution id and step id:
```elixir
Journey.Execution.get_value(execution_id, :birth_day)
```